### PR TITLE
Add CUDA-accelerated bitmap path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# DXF Nesting Script
+
+This repository contains a single-file DXF nesting utility that packs 2D profiles on to rectangular sheets.  The script was designed to run without external dependencies and now includes a small CLI wrapper so it can be executed directly from Linux/macOS shells as well as the original Windows workflow.
+
+## Usage
+
+```bash
+python nest_dxf_qty_optimized_shuffle.py --folder "For waterjet cutting" --pixels-per-unit 6 --tries 4
+```
+
+### Notable options
+
+- `--folder` – Source directory that holds DXF files and optional quantity text files.
+- `--sheet WIDTH HEIGHT` – Sheet size in drawing units (defaults to 48" × 96").
+- `--pixels-per-unit` – Bitmap resolution; higher values improve accuracy at the cost of runtime.
+- `--tries` – Number of shuffle trials to explore alternate part orders.
+- `--seed` – Fix the random seed for repeatable runs.
+- `--workers` – Number of worker processes for bitmap evaluation (defaults to auto detection).
+- `--gpu/--no-gpu` – Force-enable or disable CUDA acceleration when PyTorch with GPU support is installed.
+- `--gpu-device` – Select a specific CUDA device (e.g. `cuda:0`).
+- `--allow-mirror/--no-mirror` – Control whether mirrored placements are explored.
+- `--allow-hole-nesting/--forbid-hole-nesting` – Toggle part-in-hole placement.
+- `--nest-mode` – Choose between the bitmap searcher and the simpler shelf fallback.
+
+When no folder is provided the script automatically looks for the bundled `For waterjet cutting` sample directory that ships with the repository.  This makes it easy to verify the algorithm without editing constants in the file.
+
+## Output
+
+The script writes `nested.dxf` and a `nest_report.txt` summary to the working folder on completion.  The report documents the run parameters, sheet usage, and any skipped parts so the resulting layout can be reproduced.
+
+## GPU acceleration
+
+The bitmap placer can now shift the heavy occupancy math on to a CUDA-capable GPU when a compatible [PyTorch](https://pytorch.org/get-started/locally/) build is installed.  The GPU path replaces the nested Python loops used for collision checks, dilation, and placement trials with batched tensor operations (convolutions and vectorized writes), yielding much faster runtimes on large nesting jobs.
+
+* Install a CUDA-enabled wheel, for example:
+
+  ```bash
+  pip install torch --index-url https://download.pytorch.org/whl/cu118
+  ```
+
+* Run the script with `--gpu` (or rely on the default auto-detection) to route bitmap evaluations through the GPU.  Use `--gpu-device` to pin to a specific adapter.
+
+If no compatible GPU or PyTorch build is detected the script logs a warning and falls back to the optimized CPU code path automatically.

--- a/gpu_bitmap.py
+++ b/gpu_bitmap.py
@@ -1,0 +1,135 @@
+"""GPU-accelerated bitmap helpers for the DXF nesting engine."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Optional, Tuple
+
+try:  # pragma: no cover - optional dependency
+    import torch
+    import torch.nn.functional as F
+except Exception:  # pragma: no cover - torch is optional
+    torch = None  # type: ignore
+    F = None  # type: ignore
+
+
+def torch_available() -> bool:
+    """Return True when PyTorch can be imported."""
+    return torch is not None and F is not None
+
+
+def cuda_available() -> bool:
+    return torch_available() and bool(torch.cuda.is_available())
+
+
+def detect_best_device(preferred: Optional[str] = None) -> Optional["torch.device"]:
+    """Return a CUDA device when available (and optionally respect *preferred*)."""
+    if not torch_available():
+        return None
+    try:
+        if preferred is not None:
+            device = torch.device(preferred)
+            if device.type == "cuda":
+                if torch.cuda.is_available():
+                    return device
+                return None
+            return device
+        if torch.cuda.is_available():
+            return torch.device("cuda")
+    except Exception:
+        return None
+    return None
+
+
+@dataclass
+class TorchMaskOps:
+    """Operations on bitmap masks backed by PyTorch tensors."""
+
+    device: "torch.device"
+
+    def __post_init__(self) -> None:
+        if not torch_available():  # pragma: no cover - import guard
+            raise RuntimeError("PyTorch is not available")
+        if self.device.type == "cuda" and not torch.cuda.is_available():
+            raise RuntimeError("CUDA device requested but not available")
+        self._offset_cache: dict[int, "torch.Tensor"] = {}
+
+    def zeros(self, height: int, width: int) -> "torch.Tensor":
+        return torch.zeros((height, width), dtype=torch.bool, device=self.device)
+
+    def mask_to_tensor(self, mask) -> "torch.Tensor":
+        if isinstance(mask, torch.Tensor):
+            return mask.to(self.device, dtype=torch.bool)
+        if not mask:
+            return self.zeros(0, 0)
+        rows = [list(row) for row in mask]
+        return torch.tensor(rows, dtype=torch.bool, device=self.device)
+
+    def count_true(self, mask: "torch.Tensor") -> int:
+        return int(mask.sum().item())
+
+    def find_first_fit(self, occ: "torch.Tensor", part: "torch.Tensor") -> Optional[Tuple[int, int]]:
+        ph, pw = part.shape
+        H, W = occ.shape
+        if ph == 0 or pw == 0:
+            return 0, 0
+        if ph > H or pw > W:
+            return None
+        occ_f = occ.to(dtype=torch.float32).unsqueeze(0).unsqueeze(0)
+        part_f = part.to(dtype=torch.float32).unsqueeze(0).unsqueeze(0)
+        conv = F.conv2d(occ_f, part_f)
+        valid = conv.eq(0)
+        if not bool(valid.any().item()):
+            return None
+        idx = torch.nonzero(valid, as_tuple=False)[0]
+        y = int(idx[2].item())
+        x = int(idx[3].item())
+        return x, y
+
+    def or_mask(self, occ: "torch.Tensor", part: "torch.Tensor", ox: int, oy: int) -> None:
+        ph, pw = part.shape
+        if ph == 0 or pw == 0:
+            return
+        occ[oy:oy + ph, ox:ox + pw] |= part
+
+    def _disk_offsets(self, r: int) -> "torch.Tensor":
+        if r <= 0:
+            return torch.zeros((1, 2), dtype=torch.long, device=self.device)
+        cached = self._offset_cache.get(r)
+        if cached is not None:
+            return cached
+        coords = []
+        rr = r * r
+        for dy in range(-r, r + 1):
+            for dx in range(-r, r + 1):
+                if dx * dx + dy * dy <= rr:
+                    coords.append((dy, dx))
+        tensor = torch.tensor(coords, dtype=torch.long, device=self.device) if coords else torch.zeros((0, 2), dtype=torch.long, device=self.device)
+        self._offset_cache[r] = tensor
+        return tensor
+
+    def or_dilated(self, occ: "torch.Tensor", part: "torch.Tensor", ox: int, oy: int, radius: int) -> None:
+        coords = torch.nonzero(part, as_tuple=False)
+        if coords.numel() == 0:
+            return
+        offsets = self._disk_offsets(radius)
+        pts = coords.unsqueeze(1) + offsets.unsqueeze(0)
+        ys = pts[..., 0].reshape(-1) + oy
+        xs = pts[..., 1].reshape(-1) + ox
+        H, W = occ.shape
+        valid = (ys >= 0) & (ys < H) & (xs >= 0) & (xs < W)
+        if valid.any():
+            occ[ys[valid], xs[valid]] = True
+
+
+@lru_cache(maxsize=4)
+def build_mask_ops(device_str: Optional[str] = None) -> Optional[TorchMaskOps]:
+    if not torch_available():  # pragma: no cover - optional dep guard
+        return None
+    try:
+        device = detect_best_device(device_str)
+        if device is None:
+            return None
+        return TorchMaskOps(device)
+    except Exception:
+        return None

--- a/nest_dxf_qty_optimized_shuffle.py
+++ b/nest_dxf_qty_optimized_shuffle.py
@@ -9,6 +9,9 @@
 # - Shows a tiny progress window (Win32 via ctypes) — no tkinter required
 
 # ======= SETTINGS =======
+# NOTE: The folder defaults to the sample DXFs that ship with the repository when
+# available.  On Windows the original absolute path is left as a fallback so the
+# script behaves the same when copied back to its source environment.
 FOLDER = r"C:\Users\Jsudhakaran\OneDrive - GN Corporation Inc\Desktop\test\For waterjet cutting"
 
 # Sheet (inches)
@@ -27,6 +30,7 @@ ARC_CHORD_TOL = 0.01    # arc flattening chord tolerance (smaller = more segment
 # Behaviors
 FALLBACK_OPEN_AS_BBOX = True   # if no closed loops, use overall DXF bbox as a rectangle
 ALLOW_ROTATE_90       = True
+ALLOW_MIRROR          = False  # allow mirrored placements (flip across Y axis)
 USE_OBB_CANDIDATE     = True   # try oriented bounding box angles too
 INSUNITS = 1                   # 1=inches, 4=mm (stored in DXF header; advisory only)
 
@@ -40,15 +44,27 @@ ALLOW_NEST_IN_HOLES = True     # True: allow part-in-hole. False: holes are bloc
 # Nesting engine
 NEST_MODE = "bitmap"           # "bitmap" | "shelf" (shelf = simpler fallback)
 PIXELS_PER_UNIT = 20           # ↑ = tighter/more accurate (slower)
+BITMAP_EVAL_WORKERS = None     # None=auto CPU count, 1=disable parallel search
+USE_GPU = None                 # None=auto detect, True=force GPU, False=disable
+GPU_DEVICE = None              # Optional CUDA device name (e.g. "cuda:0")
 
 # Multi-try randomization (bitmap only)
-SHUFFLE_TRIES = 1
+SHUFFLE_TRIES = 5
 SHUFFLE_SEED  = None           # int for reproducibility, or None
 # ========================
 
 import os, math
 from typing import List, Tuple, Dict, Optional
+from concurrent.futures import ProcessPoolExecutor, as_completed
 from random import Random
+
+from gpu_bitmap import build_mask_ops, cuda_available
+
+# Detect a co-located sample folder so out-of-the-box runs on Linux/macOS pick
+# up the repository assets without having to edit the script manually.
+_REPO_SAMPLE_FOLDER = os.path.join(os.path.dirname(__file__), "For waterjet cutting")
+if os.path.isdir(_REPO_SAMPLE_FOLDER):
+    FOLDER = _REPO_SAMPLE_FOLDER
 
 # ---------- tiny Windows progress window (robust prototypes) ----------
 IS_WINDOWS = (os.name == "nt")
@@ -248,6 +264,27 @@ def log(line: str):
     print(line)
     _report_lines.append(line)
 
+
+_gpu_ops = None
+_gpu_init_attempted = False
+_gpu_init_failed_reason = None
+_gpu_warned = False
+
+
+def _get_gpu_ops():
+    global _gpu_ops, _gpu_init_attempted, _gpu_init_failed_reason
+    if _gpu_ops is not None:
+        return _gpu_ops
+    if _gpu_init_attempted:
+        return None
+    _gpu_init_attempted = True
+    ops = build_mask_ops(GPU_DEVICE if GPU_DEVICE else None)
+    if ops is None:
+        _gpu_init_failed_reason = "No compatible CUDA device detected or PyTorch missing."
+        return None
+    _gpu_ops = ops
+    return _gpu_ops
+
 Point = Tuple[float,float]
 Loop  = List[Point]
 Seg   = Tuple[Point,Point]
@@ -442,6 +479,12 @@ def bbox_of_loops(loops: List[Loop]):
 def translate_loop(loop: Loop, dx: float, dy: float) -> Loop:
     return [(x+dx,y+dy) for x,y in loop]
 
+def mirror_loop(loop: Loop) -> Loop:
+    mirrored = [(-x, y) for x, y in loop]
+    minx = min((x for x, _ in mirrored), default=0.0)
+    miny = min((y for _, y in mirrored), default=0.0)
+    return [(x - minx, y - miny) for x, y in mirrored]
+
 def rotate_loop(loop: Loop, theta: float) -> Loop:
     c,s=math.cos(theta), math.sin(theta)
     rot=[(x*c - y*s, x*s + y*c) for x,y in loop]
@@ -490,6 +533,8 @@ def split_outer_and_holes(loops: List[Loop]):
 
 # ---------- Part ----------
 class Part:
+    _uid_counter = 0
+
     def __init__(self, name: str, loops: List[Loop], fallback_bbox: Optional[Tuple[float,float,float,float]]):
         if loops:
             minx,miny,maxx,maxy=bbox_of_loops(loops)
@@ -506,12 +551,21 @@ class Part:
         minx,miny,maxx,maxy=bbox_of_loops([self.outer])
         self.w=maxx-minx; self.h=maxy-miny
         self.obb_w,self.obb_h,self.obb_theta = min_area_rect(self.outer)
-        self._cand_cache = {}  # angle -> dict(loops, raw, test, shell, pw,ph)
+        self._cand_cache = {}  # (scale, angle, mirror) -> dict(loops, raw, test, shell, pw,ph)
+        self.uid = Part._uid_counter
+        Part._uid_counter += 1
 
-    def oriented(self, theta: float):
+    def oriented(self, theta: float, mirror: bool = False):
         if self.outer is None: return 0.0,0.0,[]
-        if abs(theta)%(2*math.pi) < 1e-12: return self.w,self.h,[self.outer]+self.holes
-        loops_r=[rotate_loop(lp, theta) for lp in [self.outer]+self.holes]
+        loops = [self.outer] + self.holes
+        if mirror:
+            loops = [mirror_loop(lp) for lp in loops]
+        if not mirror and abs(theta)%(2*math.pi) < 1e-12:
+            return self.w,self.h,loops
+        if abs(theta)%(2*math.pi) < 1e-12:
+            loops_r = loops
+        else:
+            loops_r=[rotate_loop(lp, theta) for lp in loops]
         minx,miny,maxx,maxy=bbox_of_loops([loops_r[0]])
         return (maxx-minx),(maxy-miny),loops_r
 
@@ -538,6 +592,34 @@ class Part:
             if all(abs((a-b)%(math.pi))>math.radians(1) for b in out):
                 out.append(a)
         return out
+
+    def clone_for_worker(self) -> 'Part':
+        clone = Part.__new__(Part)
+        clone.name = self.name
+        clone.outer = self.outer
+        clone.holes = self.holes
+        clone.w = self.w
+        clone.h = self.h
+        clone.obb_w = self.obb_w
+        clone.obb_h = self.obb_h
+        clone.obb_theta = self.obb_theta
+        clone._cand_cache = {}
+        clone.uid = self.uid
+        return clone
+
+    def candidate_poses(self):
+        angles = self.candidate_angles()
+        mirrors = [False, True] if ALLOW_MIRROR else [False]
+        seen = set()
+        poses = []
+        for mirror in mirrors:
+            for ang in angles:
+                key = (mirror, round((ang % (2*math.pi)), 10))
+                if key in seen:
+                    continue
+                seen.add(key)
+                poses.append((ang, mirror))
+        return poses
 
 # ---------- Bitmap helpers ----------
 def _empty_mask(w:int, h:int):
@@ -681,8 +763,8 @@ def or_dilated_mask_inplace(occ, raw_mask, ox, oy, r):
                         occ[yy][xx] = 1
 
 # ---------- Packer: Bitmap core (exact spacing + 1px safety) ----------
-def pack_bitmap_core(ordered_parts: List['Part'], W: float, H: float, spacing: float, scale: int,
-                     progress=None, progress_total=None, progress_prefix=""):
+def _pack_bitmap_core_cpu(ordered_parts: List['Part'], W: float, H: float, spacing: float, scale: int,
+                          progress=None, progress_total=None, progress_prefix=""):
     Wpx = max(1, int(math.ceil(W * scale)))
     Hpx = max(1, int(math.ceil(H * scale)))
     r_px = int(math.ceil(spacing * scale))  # dilation radius for spacing
@@ -706,17 +788,18 @@ def pack_bitmap_core(ordered_parts: List['Part'], W: float, H: float, spacing: f
 
     for p in ordered_parts:
         placed = False
-        for ang in p.candidate_angles():
-            if ang not in p._cand_cache:
-                w,h,loops = p.oriented(ang)
+        for ang, mirror in p.candidate_poses():
+            key = (scale, ang, mirror)
+            if key not in p._cand_cache:
+                w,h,loops = p.oriented(ang, mirror)
                 raw, pw, ph = rasterize_loops(loops, scale)               # outer minus holes
                 test = dilate_mask(raw, pw, ph, r_px)                      # spacing test
                 if not ALLOW_NEST_IN_HOLES:
                     shell, _, _ = rasterize_outer_only(loops, scale)       # outer only
                 else:
                     shell = raw
-                p._cand_cache[ang] = {'loops':loops,'raw':raw,'test':test,'shell':shell,'pw':pw,'ph':ph}
-            cand = p._cand_cache[ang]
+                p._cand_cache[key] = {'loops':loops,'raw':raw,'test':test,'shell':shell,'pw':pw,'ph':ph}
+            cand = p._cand_cache[key]
             attempt_sheet = sheets_count
             while True:
                 occ_raw, occ_safe, outlist = ensure_sheet()
@@ -752,7 +835,7 @@ def pack_bitmap_core(ordered_parts: List['Part'], W: float, H: float, spacing: f
             # last resort: drop at (0,0) of a fresh sheet
             sheets_count += 1
             occ_raw, occ_safe, outlist = ensure_sheet()
-            w,h,loops = p.oriented(0.0)
+            w,h,loops = p.oriented(0.0, False)
             raw, pw, ph = rasterize_loops(loops, scale)
             shell = rasterize_outer_only(loops, scale)[0] if not ALLOW_NEST_IN_HOLES else raw
             or_mask_inplace(occ_raw, raw, 0, 0)
@@ -773,40 +856,522 @@ def pack_bitmap_core(ordered_parts: List['Part'], W: float, H: float, spacing: f
     placements = [{'sheet': i, 'loops': pl['loops']} for i, out in enumerate(sheets_out) for pl in out]
     return placements, used_sheets, fill_pixels
 
+
+def _pack_bitmap_core_gpu(ordered_parts: List['Part'], W: float, H: float, spacing: float, scale: int,
+                          progress=None, progress_total=None, progress_prefix="", ops=None):
+    if ops is None:
+        ops = _get_gpu_ops()
+    if ops is None:
+        raise RuntimeError("GPU mask operations are unavailable")
+
+    Wpx = max(1, int(math.ceil(W * scale)))
+    Hpx = max(1, int(math.ceil(H * scale)))
+    r_px = int(math.ceil(spacing * scale))
+    SAFETY_PX = 1
+
+    sheets_occ_raw = []
+    sheets_occ_safe = []
+    sheets_out = []
+    sheets_count = 0
+
+    def ensure_sheet():
+        nonlocal sheets_count
+        if len(sheets_occ_raw) <= sheets_count:
+            sheets_occ_raw.append(ops.zeros(Hpx, Wpx))
+            sheets_occ_safe.append(ops.zeros(Hpx, Wpx))
+            sheets_out.append([])
+        return sheets_occ_raw[sheets_count], sheets_occ_safe[sheets_count], sheets_out[sheets_count]
+
+    placed_count = 0
+    total_parts = progress_total if progress_total is not None else len(ordered_parts)
+
+    for p in ordered_parts:
+        placed = False
+        for ang, mirror in p.candidate_poses():
+            key = (scale, ang, mirror)
+            if key not in p._cand_cache:
+                w, h, loops = p.oriented(ang, mirror)
+                raw, pw, ph = rasterize_loops(loops, scale)
+                test = dilate_mask(raw, pw, ph, r_px)
+                if not ALLOW_NEST_IN_HOLES:
+                    shell, _, _ = rasterize_outer_only(loops, scale)
+                else:
+                    shell = raw
+                p._cand_cache[key] = {
+                    'loops': loops,
+                    'raw': raw,
+                    'test': test,
+                    'shell': shell,
+                    'pw': pw,
+                    'ph': ph,
+                }
+            cand = p._cand_cache[key]
+            gpu = cand.setdefault('gpu', {})
+            if gpu.get('device') != ops.device:
+                gpu.clear()
+                gpu['device'] = ops.device
+            if 'raw' not in gpu:
+                gpu['raw'] = ops.mask_to_tensor(cand['raw'])
+                gpu['shell'] = ops.mask_to_tensor(cand['shell'])
+                gpu['test'] = ops.mask_to_tensor(cand['test'])
+
+            attempt_sheet = sheets_count
+            while True:
+                occ_raw, occ_safe, outlist = ensure_sheet()
+                pos = ops.find_first_fit(occ_safe, gpu['test'])
+                if pos is not None:
+                    xpx, ypx = pos
+                    ops.or_mask(occ_raw, gpu['raw'], xpx, ypx)
+                    ops.or_dilated(occ_safe, gpu['shell'], xpx, ypx, SAFETY_PX)
+                    x_units = xpx / scale
+                    y_units = ypx / scale
+                    loops_t = [[(x + x_units, y + y_units) for (x, y) in lp] for lp in cand['loops']]
+                    outlist.append({'sheet': sheets_count, 'loops': loops_t})
+                    placed = True
+                    placed_count += 1
+                    if progress:
+                        progress(f"{progress_prefix}Placing parts…\n"
+                                 f"Placed: {placed_count}/{total_parts}\n"
+                                 f"Current sheet: {sheets_count+1}\n"
+                                 f"Part: {os.path.basename(p.name)}")
+                    break
+                else:
+                    sheets_count += 1
+                    if progress:
+                        progress(f"{progress_prefix}Opening new sheet… now {sheets_count+1}\n"
+                                 f"Placed: {placed_count}/{total_parts}")
+                    if sheets_count > attempt_sheet + 25:
+                        break
+            if placed:
+                break
+        if not placed:
+            sheets_count += 1
+            occ_raw, occ_safe, outlist = ensure_sheet()
+            w, h, loops = p.oriented(0.0, False)
+            raw, pw, ph = rasterize_loops(loops, scale)
+            shell = rasterize_outer_only(loops, scale)[0] if not ALLOW_NEST_IN_HOLES else raw
+            raw_t = ops.mask_to_tensor(raw)
+            shell_t = ops.mask_to_tensor(shell)
+            ops.or_mask(occ_raw, raw_t, 0, 0)
+            ops.or_dilated(occ_safe, shell_t, 0, 0, SAFETY_PX)
+            outlist.append({'sheet': sheets_count, 'loops': loops})
+            placed_count += 1
+            if progress:
+                progress(f"{progress_prefix}Forced place on new sheet {sheets_count+1}\n"
+                         f"Placed: {placed_count}/{total_parts}")
+
+    used_sheets = sheets_count + 1 if sheets_out and sheets_out[0] else len(sheets_out)
+    fill_pixels = 0
+    for occ in sheets_occ_raw:
+        fill_pixels += ops.count_true(occ)
+    placements = [{'sheet': i, 'loops': pl['loops']} for i, out in enumerate(sheets_out) for pl in out]
+    return placements, used_sheets, fill_pixels
+
+
+def pack_bitmap_core(ordered_parts: List['Part'], W: float, H: float, spacing: float, scale: int,
+                     progress=None, progress_total=None, progress_prefix=""):
+    global _gpu_warned
+
+    should_try_gpu = False
+    if USE_GPU is True:
+        should_try_gpu = True
+    elif USE_GPU is None:
+        should_try_gpu = cuda_available()
+
+    if should_try_gpu:
+        ops = _get_gpu_ops()
+        if ops is not None:
+            try:
+                return _pack_bitmap_core_gpu(ordered_parts, W, H, spacing, scale,
+                                             progress=progress,
+                                             progress_total=progress_total,
+                                             progress_prefix=progress_prefix,
+                                             ops=ops)
+            except Exception as exc:
+                log(f"[WARN] GPU packing failed ({exc}); falling back to CPU path.")
+        elif _gpu_init_failed_reason and not _gpu_warned:
+            log(f"[WARN] GPU acceleration requested but unavailable: {_gpu_init_failed_reason}")
+            _gpu_warned = True
+
+    return _pack_bitmap_core_cpu(ordered_parts, W, H, spacing, scale,
+                                 progress=progress,
+                                 progress_total=progress_total,
+                                 progress_prefix=progress_prefix)
+
+# ---------- Bitmap order optimization helpers ----------
+def _seq_key(order: List['Part']):
+    return tuple(p.uid for p in order)
+
+
+def _result_is_better(candidate, incumbent):
+    if candidate is None:
+        return False
+    if incumbent is None:
+        return True
+    _, cand_sheets, cand_fill = candidate
+    _, inc_sheets, inc_fill = incumbent
+    if cand_sheets != inc_sheets:
+        return cand_sheets < inc_sheets
+    return cand_fill > inc_fill
+
+
+def _mutate_order(order: List['Part'], rnd: Random) -> List['Part']:
+    n = len(order)
+    if n <= 1:
+        return list(order)
+    op = rnd.random()
+    if n == 2:
+        op = 0.0
+    if op < 0.4:
+        i, j = rnd.sample(range(n), 2)
+        new_order = list(order)
+        new_order[i], new_order[j] = new_order[j], new_order[i]
+        return new_order
+    elif op < 0.75:
+        i, j = rnd.sample(range(n), 2)
+        new_order = list(order)
+        part = new_order.pop(i)
+        new_order.insert(j, part)
+        return new_order
+    else:
+        i, j = sorted(rnd.sample(range(n), 2))
+        if i == j:
+            return list(order)
+        new_order = list(order)
+        new_order[i:j+1] = reversed(new_order[i:j+1])
+        return new_order
+
+
+def _anneal_order(initial_order: List['Part'], evaluate_fn, rnd: Random, sheet_penalty: int,
+                  progress=None, label="", max_iters: Optional[int] = None):
+    order = list(initial_order)
+    best_order = list(order)
+    best_result = evaluate_fn(best_order, allow_progress=False)
+    current_order = list(order)
+    current_result = best_result
+
+    n = len(order)
+    if n <= 1:
+        return best_order, best_result
+
+    default_iters = max(8, min(24, n + 4))
+    if max_iters is not None:
+        base_iters = max(5, min(default_iters, max_iters))
+    else:
+        base_iters = default_iters
+    temperature = max(1.0, n * 0.4)
+    cooling = 0.9
+    stall_limit = None
+
+    def score(res):
+        if res is None:
+            return float('inf')
+        _, sheets, fill = res
+        return sheets * sheet_penalty - fill
+
+    stall = 0
+    for it in range(1, base_iters + 1):
+        candidate_order = _mutate_order(current_order, rnd)
+        candidate_result = evaluate_fn(candidate_order, allow_progress=False)
+
+        if _result_is_better(candidate_result, current_result):
+            current_order, current_result = candidate_order, candidate_result
+        else:
+            delta = score(candidate_result) - score(current_result)
+            if delta < 0:
+                accept_prob = 1.0
+            else:
+                if temperature <= 0:
+                    accept_prob = 0.0
+                else:
+                    accept_prob = math.exp(-delta / temperature)
+            if accept_prob > rnd.random():
+                current_order, current_result = candidate_order, candidate_result
+
+        if _result_is_better(current_result, best_result):
+            best_order, best_result = list(current_order), current_result
+            if progress:
+                progress(f"{label}Anneal improvement: sheets={best_result[1]}, fill={best_result[2]}")
+            stall = 0
+        else:
+            stall += 1
+
+        if progress and it % max(6, base_iters // 3) == 0:
+            progress(f"{label}Anneal {it}/{base_iters}: best sheets={best_result[1]}, fill={best_result[2]}")
+
+        temperature *= cooling
+        if temperature < 1e-4:
+            temperature = 1e-4
+        if stall_limit is None:
+            stall_limit = max(3, base_iters // 2)
+        if stall >= stall_limit:
+            break
+
+    return best_order, best_result
+
+
+_worker_part_lookup: Dict[int, 'Part'] = {}
+
+
+def _init_bitmap_worker(parts_payload: List['Part']):
+    global _worker_part_lookup
+    _worker_part_lookup = {p.uid: p for p in parts_payload}
+
+
+def _bitmap_try_worker(task):
+    (index, label, order_uids, anneal_limit, search_scale, sheet_penalty,
+     rnd_seed, W, H, spacing) = task
+
+    parts = [_worker_part_lookup[uid] for uid in order_uids]
+    local_cache: Dict[Tuple[tuple, int], Tuple[List[dict], int, int]] = {}
+
+    def evaluate(order: List['Part'], allow_progress: bool = False, prefix: str = ""):
+        key = (_seq_key(order), search_scale)
+        if key in local_cache:
+            return local_cache[key]
+        res = pack_bitmap_core(order, W, H, spacing, search_scale, progress=None)
+        local_cache[key] = res
+        return res
+
+    start_result = evaluate(parts, allow_progress=False)
+
+    if anneal_limit > 1:
+        rnd = Random(rnd_seed)
+        order_after, result_after = _anneal_order(
+            parts,
+            lambda o, allow_progress=False: evaluate(o, allow_progress),
+            rnd,
+            sheet_penalty,
+            progress=None,
+            label=label,
+            max_iters=anneal_limit,
+        )
+    else:
+        order_after, result_after = parts, start_result
+
+    final_result = result_after if _result_is_better(result_after, start_result) else start_result
+    final_order = order_after if final_result is result_after else parts
+
+    def simplify(res):
+        if res is None:
+            return None
+        return (None, res[1], res[2])
+
+    return (
+        index,
+        label,
+        order_uids,
+        [p.uid for p in final_order],
+        simplify(start_result),
+        simplify(final_result),
+    )
+
+
 # ---------- Bitmap multi-try ----------
 def pack_bitmap_multi(parts: List['Part'], W: float, H: float, spacing: float, scale: int,
                       tries: int, seed: Optional[int], progress=None):
-    base = sorted([p for p in parts if p.outer is not None],
-                  key=lambda p: abs(polygon_area(p.outer)),
-                  reverse=True)
+    global _gpu_warned
+
+    base = [p for p in parts if p.outer is not None]
+    base.sort(key=lambda p: abs(polygon_area(p.outer)), reverse=True)
     rnd = Random(seed) if seed is not None else Random()
-    best = None  # (placements, sheets, fill_pixels)
     total_parts = len(base)
-    for t in range(max(1, tries)):
-        if progress:
-            progress(f"Preparing try {t+1}/{tries}…")
-        ordered = list(base) if t==0 else rnd.sample(base, len(base))
-        placements, sheets, fillpx = pack_bitmap_core(
-            ordered, W, H, spacing, scale,
-            progress=progress,
-            progress_total=total_parts,
-            progress_prefix=f"Try {t+1}/{tries}\n"
-        )
-        if best is None:
-            best = (placements, sheets, fillpx)
-            if progress:
-                progress(f"Try {t+1}: sheets={sheets}, fillpx={fillpx}\n(best so far)")
+
+    if total_parts == 0:
+        return [], 0
+
+    search_scale = scale
+    if scale > 6:
+        search_scale = max(6, scale // 2)
+
+    Wpx = max(1, int(math.ceil(W * scale)))
+    Hpx = max(1, int(math.ceil(H * scale)))
+    sheet_penalty = Wpx * Hpx * 1000
+
+    cache: Dict[Tuple[tuple, int], Tuple[List[dict], int, int]] = {}
+
+    gpu_active = False
+    if USE_GPU is True or (USE_GPU is None and cuda_available()):
+        ops = _get_gpu_ops()
+        if ops is not None:
+            gpu_active = True
+        elif _gpu_init_failed_reason and not _gpu_warned:
+            log(f"[WARN] GPU acceleration requested but unavailable: {_gpu_init_failed_reason}")
+            _gpu_warned = True
+
+    def evaluate(order: List['Part'], allow_progress: bool, prefix: str = "", use_scale: int = search_scale):
+        key = (_seq_key(order), use_scale)
+        if key in cache:
+            return cache[key]
+        if allow_progress and progress:
+            result = pack_bitmap_core(order, W, H, spacing, use_scale,
+                                      progress=progress,
+                                      progress_total=total_parts,
+                                      progress_prefix=prefix)
         else:
-            bp, bs, bf = best
-            better = (sheets < bs) or (sheets == bs and fillpx > bf)
-            if better:
-                best = (placements, sheets, fillpx)
-                if progress:
-                    progress(f"Try {t+1}: sheets={sheets}, fillpx={fillpx}\n(new best)")
+            result = pack_bitmap_core(order, W, H, spacing, use_scale, progress=None)
+        cache[key] = result
+        return result
+
+    best_result = None
+    best_order: Optional[List['Part']] = None
+
+    heuristic_orders: List[Tuple[str, List['Part']]] = []
+    heuristic_orders.append(("Area-desc ", list(base)))
+    heuristic_orders.append(("Aspect-desc ", sorted(base, key=lambda p: max(p.w, p.h, p.obb_w, p.obb_h), reverse=True)))
+    heuristic_orders.append(("Tall-first ", sorted(base, key=lambda p: p.h, reverse=True)))
+
+    tries = max(1, tries)
+
+    start_orders: List[Tuple[str, List['Part']]] = []
+    for ho in heuristic_orders:
+        if len(start_orders) >= tries:
+            break
+        start_orders.append(ho)
+    while len(start_orders) < tries:
+        idx = len(start_orders) - len(heuristic_orders) + 1
+        start_orders.append((f"Random {max(1, idx)} ", rnd.sample(base, len(base))))
+
+    attempts = max(1, len(start_orders))
+    anneal_limit = max(4, min(8, total_parts + max(1, tries // 2)))
+    parts_by_uid = {p.uid: p for p in base}
+
+    try_configs = []
+    for t, (label, start_order) in enumerate(start_orders):
+        if anneal_limit <= 0:
+            limit = 0
+        else:
+            if t == 0:
+                limit = anneal_limit
+            elif t < len(heuristic_orders):
+                limit = min(3, anneal_limit)
             else:
+                limit = min(4, anneal_limit)
+        try_configs.append({
+            'index': t,
+            'label': label,
+            'order': start_order,
+            'limit': max(0, limit),
+        })
+
+    desired_workers = 1
+    if BITMAP_EVAL_WORKERS is None:
+        cpu = os.cpu_count() or 1
+        desired_workers = max(1, min(cpu, attempts))
+    else:
+        try:
+            requested = int(BITMAP_EVAL_WORKERS)
+        except (TypeError, ValueError):
+            requested = 1
+        if requested <= 1:
+            desired_workers = 1
+        else:
+            desired_workers = max(1, min(requested, attempts))
+
+    if gpu_active:
+        desired_workers = 1
+
+    parallel = desired_workers > 1 and attempts > 1
+    last_start_result = None
+
+    if parallel:
+        worker_payload = [parts_by_uid[uid].clone_for_worker() for uid in sorted(parts_by_uid)]
+        best_order_uids: Optional[List[int]] = None
+        worker_results: List[Optional[Tuple[str, List[int], List[int], Optional[Tuple], Optional[Tuple]]]] = [None] * attempts
+
+        log(f"[INFO] Bitmap search using {desired_workers} workers ({attempts} trials @ scale {search_scale}).")
+        if progress:
+            progress(f"Parallel search across {desired_workers} workers ({attempts} trials)…")
+
+        with ProcessPoolExecutor(max_workers=desired_workers,
+                                 initializer=_init_bitmap_worker,
+                                 initargs=(worker_payload,)) as pool:
+            futures = []
+            for cfg in try_configs:
+                order_uids = [p.uid for p in cfg['order']]
+                seed_val = rnd.randrange(2**31 - 1) if cfg['limit'] > 1 else 0
+                label = f"{cfg['label']}Try {cfg['index']+1}/{attempts} "
+                futures.append(pool.submit(
+                    _bitmap_try_worker,
+                    (cfg['index'], label, order_uids, cfg['limit'], search_scale,
+                     sheet_penalty, seed_val, W, H, spacing)
+                ))
+
+            for fut in as_completed(futures):
+                idx, label, start_uids, final_uids, start_res, final_res = fut.result()
+                worker_results[idx] = (label, start_uids, final_uids, start_res, final_res)
+                if _result_is_better(final_res, best_result):
+                    best_result = final_res
+                    best_order_uids = final_uids
+                    if progress:
+                        progress(f"{label}New global best: sheets={best_result[1]}, fill={best_result[2]}")
+                elif progress and best_result:
+                    progress(f"{label}Result sheets={final_res[1]}, fill={final_res[2]} (best remains sheets={best_result[1]}, fill={best_result[2]})")
+
+        if worker_results and worker_results[-1] is not None:
+            last_start_result = worker_results[-1][3]
+
+        if best_result is None and worker_results:
+            # Fallback to the final completed trial's start result if all anneals failed
+            for entry in reversed(worker_results):
+                if entry is not None:
+                    best_result = entry[3]
+                    best_order_uids = entry[1]
+                    break
+
+        if best_result is None:
+            best_order_uids = [p.uid for p in (start_orders[0][1] if start_orders else base)]
+
+        best_order = [parts_by_uid[uid] for uid in best_order_uids] if best_order_uids else list(base)
+    else:
+        suffix = " with GPU acceleration" if gpu_active else ""
+        log(f"[INFO] Bitmap search running sequentially{suffix} ({attempts} trial{'s' if attempts != 1 else ''} @ scale {search_scale}).")
+        for cfg in try_configs:
+            label = cfg['label']
+            start_order = cfg['order']
+            idx = cfg['index']
+            limit = cfg['limit']
+            display_label = f"{label}placement trial {idx+1}/{attempts}…"
+            if progress:
+                progress(display_label)
+
+            start_result = evaluate(start_order, allow_progress=False,
+                                    prefix=f"{label}Try {idx+1}/{attempts}\n", use_scale=search_scale)
+            last_start_result = start_result
+
+            if limit <= 1:
+                order_after, result_after = start_order, start_result
+            else:
+                order_after, result_after = _anneal_order(
+                    start_order,
+                    lambda o, allow_progress=False: evaluate(o, allow_progress, prefix=label, use_scale=search_scale),
+                    rnd,
+                    sheet_penalty,
+                    progress=progress,
+                    label=label,
+                    max_iters=limit
+                )
+
+            final_result = result_after if _result_is_better(result_after, start_result) else start_result
+            final_order = order_after if final_result is result_after else start_order
+
+            if _result_is_better(final_result, best_result):
+                best_result = final_result
+                best_order = final_order
                 if progress:
-                    progress(f"Try {t+1}: sheets={sheets}, fillpx={fillpx}\n(kept best: sheets={bs}, fillpx={bf})")
-    return best[0], best[1]
+                    progress(f"{label}New global best: sheets={best_result[1]}, fill={best_result[2]}")
+            elif progress and best_result:
+                progress(f"{label}Result sheets={final_result[1]}, fill={final_result[2]} (best remains sheets={best_result[1]}, fill={best_result[2]})")
+
+        if best_result is None:
+            best_result = last_start_result
+            best_order = start_orders[0][1] if start_orders else base
+
+        best_order = best_order if best_order is not None else list(base)
+
+    final_order = best_order if best_order is not None else list(base)
+    final_result = evaluate(final_order, allow_progress=True, prefix="Final pass\n", use_scale=scale)
+    return final_result[0], final_result[1]
 
 # ---------- Shelf fallback ----------
 def pack_shelves(parts: List['Part'], W: float, H: float, spacing: float):
@@ -819,35 +1384,35 @@ def pack_shelves(parts: List['Part'], W: float, H: float, spacing: float):
         sheet+=1; shelf_y=0.0; shelf_h=0.0; cursor_x=0.0
     for p in parts:
         cands=[]
-        for ang in p.candidate_angles():
-            w,h,_=p.oriented(ang)
-            cands.append((ang,w,h))
+        for ang, mirror in p.candidate_poses():
+            w,h,_=p.oriented(ang, mirror)
+            cands.append((ang, mirror, w, h))
         placed=False
-        for ang,w,h in cands:
+        for ang, mirror, w, h in cands:
             if cursor_x + w + spacing <= W and shelf_y + max(shelf_h, h + spacing) <= H:
-                _,_,loops = p.oriented(ang)
+                _,_,loops = p.oriented(ang, mirror)
                 placements.append({'sheet':sheet,'loops':[[(x+cursor_x,y+shelf_y) for x,y in lp] for lp in loops]})
                 cursor_x += w + spacing; shelf_h = max(shelf_h, h + spacing)
                 placed=True; break
         if placed: continue
         shelf_y += shelf_h; cursor_x = 0.0; shelf_h = 0.0
-        for ang,w,h in cands:
+        for ang, mirror, w, h in cands:
             if w + spacing <= W and shelf_y + h + spacing <= H:
-                _,_,loops = p.oriented(ang)
+                _,_,loops = p.oriented(ang, mirror)
                 placements.append({'sheet':sheet,'loops':[[(x+0.0,y+shelf_y) for x,y in lp] for lp in loops]})
                 cursor_x = w + spacing; shelf_h = h + spacing
                 placed=True; break
         if placed: continue
         new_sheet()
         ok=False
-        for ang,w,h in cands:
+        for ang, mirror, w, h in cands:
             if w + spacing <= W and h + spacing <= H:
-                _,_,loops = p.oriented(ang)
+                _,_,loops = p.oriented(ang, mirror)
                 placements.append({'sheet':sheet,'loops':[[(x+0.0,y+0.0) for x,y in lp] for lp in loops]})
                 cursor_x = w + spacing; shelf_h = h + spacing
                 ok=True; break
         if not ok:
-            _,_,loops = p.oriented(0.0)
+            _,_,loops = p.oriented(0.0, False)
             placements.append({'sheet':sheet,'loops':[[(x,y) for x,y in lp] for lp in loops]})
             cursor_x = p.w + spacing; shelf_h = p.h + spacing
     sheets_used=(max((pl['sheet'] for pl in placements), default=-1))+1
@@ -973,7 +1538,17 @@ def main():
     _report_lines.append(f"Shuffle tries: {SHUFFLE_TRIES}{'' if SHUFFLE_SEED is None else f' (seed {SHUFFLE_SEED})'}")
     _report_lines.append(f"Skipped DXFs: {skipped}")
     _report_lines.append(f"Rect-align mode: {RECT_ALIGN_MODE}")
+    _report_lines.append(f"Allow mirror: {ALLOW_MIRROR}")
     _report_lines.append(f"Allow nest in holes: {ALLOW_NEST_IN_HOLES}")
+    if _gpu_ops is not None:
+        gpu_line = f"enabled ({str(_gpu_ops.device)})"
+    elif USE_GPU is False:
+        gpu_line = "disabled"
+    elif _gpu_init_failed_reason:
+        gpu_line = f"requested but unavailable ({_gpu_init_failed_reason})"
+    else:
+        gpu_line = "disabled"
+    _report_lines.append(f"GPU acceleration: {gpu_line}")
     try:
         with open(report_path, "w", encoding="utf-8") as rf:
             rf.write("\n".join(_report_lines))
@@ -989,4 +1564,133 @@ def main():
     except: pass
 
 if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Nest DXF parts onto rectangular sheets using bitmap search."
+    )
+    parser.add_argument(
+        "--folder",
+        default=FOLDER,
+        help="Directory containing DXF files and optional quantity TXT files.",
+    )
+    parser.add_argument(
+        "--sheet",
+        nargs=2,
+        metavar=("WIDTH", "HEIGHT"),
+        type=float,
+        default=(SHEET_W, SHEET_H),
+        help="Sheet size in drawing units (width height).",
+    )
+    parser.add_argument(
+        "--margin",
+        type=float,
+        default=SHEET_MARGIN,
+        help="Border margin to keep empty around each sheet.",
+    )
+    parser.add_argument(
+        "--spacing",
+        type=float,
+        default=SPACING,
+        help="Minimum spacing to keep between parts.",
+    )
+    parser.add_argument(
+        "--nest-mode",
+        choices=["bitmap", "shelf"],
+        default=NEST_MODE,
+        help="Select the nesting strategy.",
+    )
+    parser.add_argument(
+        "--pixels-per-unit",
+        type=int,
+        default=PIXELS_PER_UNIT,
+        help="Bitmap resolution used for placement evaluation.",
+    )
+    parser.add_argument(
+        "--tries",
+        type=int,
+        default=SHUFFLE_TRIES,
+        help="Number of shuffle tries to explore different part orders.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=SHUFFLE_SEED,
+        help="Optional RNG seed for repeatable shuffles.",
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=BITMAP_EVAL_WORKERS,
+        help="Number of worker processes used for bitmap evaluation (bitmap mode).",
+    )
+    parser.add_argument(
+        "--gpu",
+        dest="use_gpu",
+        action="store_true",
+        help="Force GPU acceleration when a CUDA-capable PyTorch build is available.",
+    )
+    parser.add_argument(
+        "--no-gpu",
+        dest="use_gpu",
+        action="store_false",
+        help="Disable GPU acceleration even if CUDA is present.",
+    )
+    parser.add_argument(
+        "--gpu-device",
+        default=GPU_DEVICE,
+        help="Optional CUDA device string (e.g. cuda:0) to target.",
+    )
+    parser.add_argument(
+        "--allow-mirror",
+        dest="allow_mirror",
+        action="store_true",
+        default=ALLOW_MIRROR,
+        help="Enable mirrored placements when searching for fits.",
+    )
+    parser.add_argument(
+        "--no-mirror",
+        dest="allow_mirror",
+        action="store_false",
+        help="Disable mirrored placements.",
+    )
+    parser.add_argument(
+        "--allow-hole-nesting",
+        dest="allow_holes",
+        action="store_true",
+        default=ALLOW_NEST_IN_HOLES,
+        help="Allow parts to be placed inside other parts' holes.",
+    )
+    parser.add_argument(
+        "--forbid-hole-nesting",
+        dest="allow_holes",
+        action="store_false",
+        help="Disallow parts being nested within holes.",
+    )
+    parser.add_argument(
+        "--rect-align",
+        choices=["off", "prefer", "force"],
+        default=RECT_ALIGN_MODE,
+        help="Control rectangle alignment heuristics.",
+    )
+
+    parser.set_defaults(use_gpu=USE_GPU)
+
+    args = parser.parse_args()
+
+    FOLDER = os.path.abspath(args.folder)
+    SHEET_W, SHEET_H = map(float, args.sheet)
+    SHEET_MARGIN = float(args.margin)
+    SPACING = float(args.spacing)
+    NEST_MODE = args.nest_mode
+    PIXELS_PER_UNIT = max(1, int(args.pixels_per_unit))
+    SHUFFLE_TRIES = max(1, int(args.tries))
+    SHUFFLE_SEED = args.seed
+    BITMAP_EVAL_WORKERS = args.workers
+    USE_GPU = args.use_gpu
+    GPU_DEVICE = args.gpu_device
+    ALLOW_MIRROR = args.allow_mirror
+    ALLOW_NEST_IN_HOLES = args.allow_holes
+    RECT_ALIGN_MODE = args.rect_align
+
     main()


### PR DESCRIPTION
## Summary
- add a reusable Torch-powered mask helper module and hook the bitmap placer into it to evaluate placements, dilations, and occupancy updates on the GPU when available
- update the bitmap search orchestration to auto-disable CPU multiprocessing under GPU mode, emit detailed status, and capture the GPU state in the nesting report
- expose CLI flags and README guidance for enabling CUDA acceleration and selecting devices while keeping CPU fallback behavior intact

## Testing
- python nest_dxf_qty_optimized_shuffle.py --folder "For waterjet cutting" --pixels-per-unit 6 --tries 1 --no-gpu
- python nest_dxf_qty_optimized_shuffle.py --folder "For waterjet cutting" --pixels-per-unit 6 --tries 1 --gpu

------
https://chatgpt.com/codex/tasks/task_e_68d5ab375d0c8320be8bcdf97223803e