### PR TITLE
Fix default worker count for nesting CLI

### DIFF
--- a/nest_dxf_qty_optimized_shuffle.py
+++ b/nest_dxf_qty_optimized_shuffle.py
@@ -48,6 +48,10 @@ NEST_MODE = "bitmap"           # "bitmap" | "shelf" (shelf = simpler fallback)
 
 PIXELS_PER_UNIT = 20           # ↑ = tighter/more accurate (slower)
 
+# Worker processes used by the bitmap evaluator.  Leaving this at ``None``
+# lets the script auto-detect the CPU count once ``os`` is available.
+BITMAP_EVAL_WORKERS = None
+
 # Multi-try randomization (bitmap only)
 SHUFFLE_TRIES = 5
 
@@ -64,6 +68,10 @@ from random import Random
 _REPO_SAMPLE_FOLDER = os.path.join(os.path.dirname(__file__), "For waterjet cutting")
 if os.path.isdir(_REPO_SAMPLE_FOLDER):
     FOLDER = _REPO_SAMPLE_FOLDER
+
+if not BITMAP_EVAL_WORKERS:
+    cpu_count = os.cpu_count() or 1
+    BITMAP_EVAL_WORKERS = max(1, cpu_count)
 
 # ---------- tiny Windows progress window (robust prototypes) ----------
 IS_WINDOWS = (os.name == "nt")


### PR DESCRIPTION
## Summary
- add a default value for the bitmap evaluation worker count that auto-detects the host CPU cores
- keep the existing behaviour of overriding the worker count through the CLI

## Testing
- python3 nest_dxf_qty_optimized_shuffle.py --folder "For waterjet cutting" --pixels-per-unit 6 --tries 2

------
https://chatgpt.com/codex/tasks/task_e_68d5eab18ab48320ab5e6494fc001afb