### PR TITLE
Add optional GPU acceleration for bitmap nesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,8 @@ When no folder is provided the script automatically looks for the bundled `For w
 ## Output
 
 The script writes `nested.dxf` and a `nest_report.txt` summary to the working folder on completion.  The report documents the run parameters, sheet usage, and any skipped parts so the resulting layout can be reproduced.
+
+## GPU acceleration
+
+- When PyTorch with CUDA support is available, the bitmap packer automatically switches to the fastest GPU device it can access. Use `--device cuda:0` (or another device string) to explicitly select which GPU should be used, or `--device cpu` to fall back to the CPU implementation.
+- The `nest_report.txt` file records whether a CUDA GPU was engaged, so you can verify that an NVIDIA device handled the workload. This is the preferred path for reducing runtime; DirectX is not required.


### PR DESCRIPTION
## Summary
- add optional PyTorch-backed bitmap operations so CUDA GPUs can accelerate placement and record their usage in the report
- expose a `--device` CLI flag to choose the accelerator and log/report when CUDA is active
- document the GPU workflow and verification steps in the README

## Testing
- python3 nest_dxf_qty_optimized_shuffle.py --folder "For waterjet cutting" --pixels-per-unit 6 --tries 2 --device cpu


------
https://chatgpt.com/codex/tasks/task_e_68d5eab18ab48320ab5e6494fc001afb