### PR TITLE
Harden DXF nesting CLI error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,8 @@ When no folder is provided the script automatically looks for the bundled `For w
 ## Output
 
 The script writes `nested.dxf` and a `nest_report.txt` summary to the working folder on completion.  The report documents the run parameters, sheet usage, and any skipped parts so the resulting layout can be reproduced.
+
+## GPU acceleration
+
+- When PyTorch with CUDA support is available, the bitmap packer automatically switches to the fastest GPU device it can access. Use `--device cuda:0` (or another device string) to explicitly select which GPU should be used, or `--device cpu` to fall back to the CPU implementation.
+- The `nest_report.txt` file records whether a CUDA GPU was engaged, so you can verify that an NVIDIA device handled the workload. This is the preferred path for reducing runtime; DirectX is not required.


### PR DESCRIPTION
## Summary
- write nest_report.txt for early exits and fall back to the script directory when the target folder is missing
- add clearer CPU device selection messaging and ensure report metadata is produced through a shared helper
- wrap the CLI entry point in an exception guard that logs failures and keeps the Windows console open when launched by double-click

## Testing
- python3 nest_dxf_qty_optimized_shuffle.py --folder 'For waterjet cutting' --pixels-per-unit 6 --tries 1 --device cpu
- python3 nest_dxf_qty_optimized_shuffle.py --folder missing_folder


------
https://chatgpt.com/codex/tasks/task_e_68d5eab18ab48320ab5e6494fc001afb