### PR TITLE
Enhance console feedback and Deepnest-inspired heuristics

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,13 @@ When no folder is provided the script automatically looks for the bundled `For w
 ## Output
 
 The script writes `nested.dxf` and a `nest_report.txt` summary to the working folder on completion.  The report documents the run parameters, sheet usage, and any skipped parts so the resulting layout can be reproduced.
+
+## GPU acceleration
+
+- When PyTorch with CUDA support is available, the bitmap packer automatically switches to the fastest GPU device it can access. Use `--device cuda:0` (or another device string) to explicitly select which GPU should be used, or `--device cpu` to fall back to the CPU implementation.
+- The `nest_report.txt` file records whether a CUDA GPU was engaged, so you can verify that an NVIDIA device handled the workload. This is the preferred path for reducing runtime; DirectX is not required.
+- On Linux and macOS the script now mirrors its Windows progress window with console updates so you can observe progress directly in the terminal. The final report also enumerates the ordering heuristics that were evaluated.
+
+## Deepnest-inspired heuristics
+
+After reviewing [Jack000/Deepnest](https://github.com/Jack000/Deepnest), the bitmap packer now seeds its search with additional ordering heuristics that mimic Deepnest's fitness priorities (part area, bounding box fill ratio, and perimeter). These extra seeds improve the chance of finding a dense layout within a limited number of shuffle tries while preserving the lightweight single-file implementation.

--- a/nest_dxf_qty_optimized_shuffle.py
+++ b/nest_dxf_qty_optimized_shuffle.py
@@ -48,22 +48,51 @@ NEST_MODE = "bitmap"           # "bitmap" | "shelf" (shelf = simpler fallback)
 
 PIXELS_PER_UNIT = 20           # ↑ = tighter/more accurate (slower)
 
+# Worker processes used by the bitmap evaluator.  Leaving this at ``None``
+# lets the script auto-detect the CPU count once ``os`` is available.
+BITMAP_EVAL_WORKERS = None
+
+# Optional PyTorch device string for the bitmap accelerator ("cuda", "cuda:0", "cpu", etc.).
+BITMAP_DEVICE = None  # type: Optional[str]
+
 # Multi-try randomization (bitmap only)
 SHUFFLE_TRIES = 5
 
 SHUFFLE_SEED  = None           # int for reproducibility, or None
 # ========================
 
-import os, math
-from typing import List, Tuple, Dict, Optional
+import os, math, sys, traceback
+from typing import List, Tuple, Dict, Optional, Any, TYPE_CHECKING
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from random import Random
+
+GPU_BACKEND_ERROR: Optional[Exception] = None
+
+try:
+    from gpu_bitmap import build_mask_ops, cuda_available
+except Exception as exc:  # pragma: no cover - optional dependency
+    GPU_BACKEND_ERROR = exc
+
+    def build_mask_ops(_device: Optional[str] = None) -> Optional['TorchMaskOps']:
+        return None
+
+    def cuda_available() -> bool:
+        return False
+else:
+    GPU_BACKEND_ERROR = None
+
+if TYPE_CHECKING:
+    from gpu_bitmap import TorchMaskOps
 
 # Detect a co-located sample folder so out-of-the-box runs on Linux/macOS pick
 # up the repository assets without having to edit the script manually.
 _REPO_SAMPLE_FOLDER = os.path.join(os.path.dirname(__file__), "For waterjet cutting")
 if os.path.isdir(_REPO_SAMPLE_FOLDER):
     FOLDER = _REPO_SAMPLE_FOLDER
+
+if not BITMAP_EVAL_WORKERS:
+    cpu_count = os.cpu_count() or 1
+    BITMAP_EVAL_WORKERS = max(1, cpu_count)
 
 # ---------- tiny Windows progress window (robust prototypes) ----------
 IS_WINDOWS = (os.name == "nt")
@@ -251,17 +280,68 @@ if IS_WINDOWS:
                 pass
 else:
     class WinProgress:
-        def __init__(self, *_, **__): self.enabled=False
-        def create(self): pass
-        def update(self, _): pass
-        def pump(self): pass
-        def close(self): pass
+        """Console-friendly progress reporter used on non-Windows hosts."""
+
+        def __init__(self, title: str = "Nesting DXF…", *_: object, **__: object) -> None:
+            self.enabled = True
+            self._last_line: Optional[str] = None
+            self.title = title
+
+        def create(self) -> None:
+            if not self.enabled:
+                return
+            banner = f"=== {self.title} ==="
+            print(banner)
+            self._last_line = banner
+
+        def update(self, text: str) -> None:
+            if not self.enabled:
+                return
+            if text == self._last_line:
+                return
+            print(text)
+            self._last_line = text
+
+        def pump(self) -> None:  # pragma: no cover - no-op for console fallback
+            return
+
+        def close(self) -> None:
+            self.enabled = False
+
 
 # --------- simple logger ----------
 _report_lines: List[str] = []
 def log(line: str):
     print(line)
     _report_lines.append(line)
+
+
+def _write_report(folder: str, extra_lines: Optional[List[str]] = None) -> Optional[str]:
+    """Persist the accumulated log/report lines.
+
+    The report normally lives alongside the DXFs, but if that directory is
+    unavailable we fall back to the script directory so errors are still
+    captured when the script exits early.
+    """
+
+    target_dir = folder if folder and os.path.isdir(folder) else os.path.dirname(os.path.abspath(__file__))
+    report_path = os.path.join(target_dir, "nest_report.txt")
+
+    payload: List[str] = ["=== Nesting Report ==="]
+    payload.extend(_report_lines)
+    if extra_lines:
+        if payload and payload[-1] != "":
+            payload.append("")
+        payload.extend(extra_lines)
+
+    try:
+        with open(report_path, "w", encoding="utf-8") as rf:
+            rf.write("\n".join(payload) + "\n")
+    except Exception as exc:
+        print(f"[WARN] Could not write report: {exc}")
+        return None
+
+    return report_path
 
 Point = Tuple[float,float]
 Loop  = List[Point]
@@ -445,6 +525,14 @@ def polygon_area(loop: Loop) -> float:
         x1,y1=loop[i]; x2,y2=loop[i+1]
         s += x1*y2 - x2*y1
     return 0.5*s
+
+def polygon_perimeter(loop: Loop) -> float:
+    peri = 0.0
+    for i in range(len(loop)-1):
+        x1, y1 = loop[i]
+        x2, y2 = loop[i + 1]
+        peri += math.hypot(x2 - x1, y2 - y1)
+    return peri
 
 def bbox_of_points(pts: List[Point]):
     xs=[p[0] for p in pts]; ys=[p[1] for p in pts]
@@ -757,22 +845,27 @@ def or_dilated_mask_inplace(occ, raw_mask, ox, oy, r):
 
 # ---------- Packer: Bitmap core (exact spacing + 1px safety) ----------
 def pack_bitmap_core(ordered_parts: List['Part'], W: float, H: float, spacing: float, scale: int,
-                     progress=None, progress_total=None, progress_prefix=""):
+                     progress=None, progress_total=None, progress_prefix="",
+                     mask_ops: Optional['TorchMaskOps'] = None):
     Wpx = max(1, int(math.ceil(W * scale)))
     Hpx = max(1, int(math.ceil(H * scale)))
     r_px = int(math.ceil(spacing * scale))  # dilation radius for spacing
     SAFETY_PX = 1                           # tiny safety to kill aliasing leaks
 
-    sheets_occ_raw  = []  # stored raw occupancy
-    sheets_occ_safe = []  # safety-extended occupancy (1px) for overlap tests
+    sheets_occ_raw: List[Any] = []  # stored raw occupancy
+    sheets_occ_safe: List[Any] = []  # safety-extended occupancy (1px) for overlap tests
     sheets_out = []
     sheets_count = 0
 
     def ensure_sheet():
         nonlocal sheets_count
         if len(sheets_occ_raw) <= sheets_count:
-            sheets_occ_raw.append(_empty_mask(Wpx, Hpx))
-            sheets_occ_safe.append(_empty_mask(Wpx, Hpx))
+            if mask_ops:
+                sheets_occ_raw.append(mask_ops.zeros(Hpx, Wpx))
+                sheets_occ_safe.append(mask_ops.zeros(Hpx, Wpx))
+            else:
+                sheets_occ_raw.append(_empty_mask(Wpx, Hpx))
+                sheets_occ_safe.append(_empty_mask(Wpx, Hpx))
             sheets_out.append([])
         return sheets_occ_raw[sheets_count], sheets_occ_safe[sheets_count], sheets_out[sheets_count]
 
@@ -797,16 +890,31 @@ def pack_bitmap_core(ordered_parts: List['Part'], W: float, H: float, spacing: f
                 p._cand_cache[key] = {'loops':loops,'raw':raw,'test':test,'shell':shell,'pw':pw,'ph':ph}
             cand = p._cand_cache[key]
 
+            if mask_ops:
+                if 'raw_tensor' not in cand:
+                    cand['raw_tensor'] = mask_ops.mask_to_tensor(cand['raw'])
+                if 'test_tensor' not in cand:
+                    cand['test_tensor'] = mask_ops.mask_to_tensor(cand['test'])
+                if 'shell_tensor' not in cand:
+                    cand['shell_tensor'] = mask_ops.mask_to_tensor(cand['shell'])
+
             attempt_sheet = sheets_count
             while True:
                 occ_raw, occ_safe, outlist = ensure_sheet()
                 # test for free spot against safety occupancy
-                pos = bl_place(occ_safe, cand['test'])
+                if mask_ops:
+                    pos = mask_ops.find_first_fit(occ_safe, cand['test_tensor'])
+                else:
+                    pos = bl_place(occ_safe, cand['test'])
                 if pos is not None:
                     xpx, ypx = pos
                     # commit: raw into raw-occ; safety-dilated shell/raw into safety-occ
-                    or_mask_inplace(occ_raw,  cand['raw'],   xpx, ypx)
-                    or_dilated_mask_inplace(occ_safe, cand['shell'], xpx, ypx, SAFETY_PX)
+                    if mask_ops:
+                        mask_ops.or_mask(occ_raw, cand['raw_tensor'], xpx, ypx)
+                        mask_ops.or_dilated(occ_safe, cand['shell_tensor'], xpx, ypx, SAFETY_PX)
+                    else:
+                        or_mask_inplace(occ_raw,  cand['raw'],   xpx, ypx)
+                        or_dilated_mask_inplace(occ_safe, cand['shell'], xpx, ypx, SAFETY_PX)
                     # record geometry in units
                     x_units = xpx / scale
                     y_units = ypx / scale
@@ -836,8 +944,14 @@ def pack_bitmap_core(ordered_parts: List['Part'], W: float, H: float, spacing: f
             w,h,loops = p.oriented(0.0, False)
             raw, pw, ph = rasterize_loops(loops, scale)
             shell = rasterize_outer_only(loops, scale)[0] if not ALLOW_NEST_IN_HOLES else raw
-            or_mask_inplace(occ_raw, raw, 0, 0)
-            or_dilated_mask_inplace(occ_safe, shell, 0, 0, SAFETY_PX)
+            if mask_ops:
+                raw_tensor = mask_ops.mask_to_tensor(raw)
+                shell_tensor = mask_ops.mask_to_tensor(shell)
+                mask_ops.or_mask(occ_raw, raw_tensor, 0, 0)
+                mask_ops.or_dilated(occ_safe, shell_tensor, 0, 0, SAFETY_PX)
+            else:
+                or_mask_inplace(occ_raw, raw, 0, 0)
+                or_dilated_mask_inplace(occ_safe, shell, 0, 0, SAFETY_PX)
             outlist.append({'sheet': sheets_count, 'loops': loops})
 
             placed_count += 1
@@ -847,10 +961,13 @@ def pack_bitmap_core(ordered_parts: List['Part'], W: float, H: float, spacing: f
 
     used_sheets = sheets_count + 1 if sheets_out and sheets_out[0] else len(sheets_out)
     # utilization metric (raw pixels)
-    fill_pixels = 0
-    for occ in sheets_occ_raw:
-        for row in occ:
-            fill_pixels += sum(1 for v in row if v)
+    if mask_ops:
+        fill_pixels = sum(mask_ops.count_true(occ) for occ in sheets_occ_raw)
+    else:
+        fill_pixels = 0
+        for occ in sheets_occ_raw:
+            for row in occ:
+                fill_pixels += sum(1 for v in row if v)
 
 
     placements = [{'sheet': i, 'loops': pl['loops']} for i, out in enumerate(sheets_out) for pl in out]
@@ -969,7 +1086,8 @@ def _anneal_order(initial_order: List['Part'], evaluate_fn, rnd: Random, sheet_p
 
 # ---------- Bitmap multi-try ----------
 def pack_bitmap_multi(parts: List['Part'], W: float, H: float, spacing: float, scale: int,
-                      tries: int, seed: Optional[int], progress=None):
+                      tries: int, seed: Optional[int], progress=None,
+                      mask_ops: Optional['TorchMaskOps'] = None):
     base = [p for p in parts if p.outer is not None]
     base.sort(key=lambda p: abs(polygon_area(p.outer)), reverse=True)
     rnd = Random(seed) if seed is not None else Random()
@@ -996,19 +1114,31 @@ def pack_bitmap_multi(parts: List['Part'], W: float, H: float, spacing: float, s
             result = pack_bitmap_core(order, W, H, spacing, use_scale,
                                       progress=progress,
                                       progress_total=total_parts,
-                                      progress_prefix=prefix)
+                                      progress_prefix=prefix,
+                                      mask_ops=mask_ops)
         else:
-            result = pack_bitmap_core(order, W, H, spacing, use_scale, progress=None)
+            result = pack_bitmap_core(order, W, H, spacing, use_scale, progress=None, mask_ops=mask_ops)
         cache[key] = result
         return result
 
     best_result = None
     best_order: Optional[List['Part']] = None
+    best_label: Optional[str] = None
+    tested_labels: List[str] = []
+
+    def deepnest_like_key(part: 'Part') -> Tuple[float, float, float, float]:
+        area = abs(polygon_area(part.outer)) if part.outer else 0.0
+        obb_area = max(part.obb_w * part.obb_h, part.w * part.h)
+        fill_ratio = (area / obb_area) if obb_area > 0 else 0.0
+        perimeter = polygon_perimeter(part.outer) if part.outer else 0.0
+        long_side = max(part.w, part.h, part.obb_w, part.obb_h)
+        return (area, fill_ratio, -perimeter, -long_side)
 
     heuristic_orders: List[Tuple[str, List['Part']]] = []
     heuristic_orders.append(("Area-desc ", list(base)))
     heuristic_orders.append(("Aspect-desc ", sorted(base, key=lambda p: max(p.w, p.h, p.obb_w, p.obb_h), reverse=True)))
     heuristic_orders.append(("Tall-first ", sorted(base, key=lambda p: p.h, reverse=True)))
+    heuristic_orders.append(("Deepnest-fit ", sorted(base, key=deepnest_like_key, reverse=True)))
 
     tries = max(1, tries)
 
@@ -1025,6 +1155,7 @@ def pack_bitmap_multi(parts: List['Part'], W: float, H: float, spacing: float, s
     anneal_limit = max(4, min(8, total_parts + max(1, tries // 2)))
     last_start_result = None
     for t, (label, start_order) in enumerate(start_orders):
+        tested_labels.append(label.strip())
         if progress:
             progress(f"{label}placement trial {t+1}/{attempts}…")
 
@@ -1058,6 +1189,7 @@ def pack_bitmap_multi(parts: List['Part'], W: float, H: float, spacing: float, s
         if _result_is_better(final_result, best_result):
             best_result = final_result
             best_order = final_order
+            best_label = label.strip()
             if progress:
                 progress(f"{label}New global best: sheets={best_result[1]}, fill={best_result[2]}")
         elif progress and best_result:
@@ -1069,7 +1201,12 @@ def pack_bitmap_multi(parts: List['Part'], W: float, H: float, spacing: float, s
 
     final_order = best_order if best_order is not None else base
     final_result = evaluate(final_order, allow_progress=True, prefix="Final pass\n", use_scale=scale)
-    return final_result[0], final_result[1]
+    stats = {
+        'fill_pixels': final_result[2] if final_result else None,
+        'best_seed': best_label,
+        'tested_orders': tested_labels,
+    }
+    return final_result[0], final_result[1], stats
 
 
 # ---------- Shelf fallback ----------
@@ -1152,22 +1289,30 @@ def write_r12_dxf(path, sheets, W, H, placements, margin):
 def main():
     prog = WinProgress("Nesting DXF… Please wait", 480, 220)
     prog.create()
+    log(f"[INFO] Nesting folder: {FOLDER}")
 
     if not os.path.isdir(FOLDER):
         log(f"[ERROR] Folder not found: {FOLDER}")
-        prog.update("Folder not found.\nCheck FOLDER path in the script."); prog.close(); return
+        prog.update("Folder not found.\nCheck FOLDER path in the script.")
+        _write_report(FOLDER, ["Status: failed (folder not found)"])
+        prog.close(); return
 
     dxf_files = sorted([f for f in os.listdir(FOLDER)
                         if f.lower().endswith(".dxf") and f.lower() != "nested.dxf"])
     if not dxf_files:
         log(f"[WARN] No .dxf files found in: {FOLDER}")
-        prog.update("No .dxf files found.\nAdd DXFs to the folder and rerun."); prog.close(); return
+        prog.update("No .dxf files found.\nAdd DXFs to the folder and rerun.")
+        _write_report(FOLDER, ["Status: aborted (no DXFs found)"])
+        prog.close(); return
 
     W_eff = SHEET_W - 2*SHEET_MARGIN
     H_eff = SHEET_H - 2*SHEET_MARGIN
     if W_eff <= 0 or H_eff <= 0:
         msg = f"[ERROR] SHEET_MARGIN={SHEET_MARGIN} leaves no usable area on a {SHEET_W}×{SHEET_H} sheet."
-        log(msg); prog.update(msg); prog.close(); return
+        log(msg)
+        prog.update(msg)
+        _write_report(FOLDER, ["Status: failed (invalid sheet margin)"])
+        prog.close(); return
 
     parts: List[Part] = []
     skipped = 0
@@ -1201,61 +1346,146 @@ def main():
     if not parts:
         log("[WARN] Nothing to nest (no usable profiles).")
         prog.update("Nothing to nest.\nNo usable closed profiles were found.")
+        _write_report(FOLDER, [
+            "Status: aborted (no usable profiles)",
+            "Details: DXFs parsed, but no closed loops were available for nesting.",
+        ])
         prog.close(); return
+
+    if GPU_BACKEND_ERROR is not None:
+        log(f"[WARN] GPU helpers unavailable ({GPU_BACKEND_ERROR.__class__.__name__}: {GPU_BACKEND_ERROR}). Running on CPU bitmaps.")
+
+    mask_ops: Optional['TorchMaskOps'] = None
+    accel_note = "Acceleration: CPU bitmap evaluator"
+    using_cuda = False
+    device_pref = BITMAP_DEVICE.strip() if BITMAP_DEVICE else None
+    if NEST_MODE.lower() == "bitmap":
+        mask_ops = build_mask_ops(device_pref)
+        if mask_ops:
+            device_desc = f"{mask_ops.device}"
+            if getattr(mask_ops.device, "type", "") == "cuda":
+                using_cuda = True
+                accel_note = f"Acceleration: CUDA GPU ({device_desc}) via PyTorch"
+            else:
+                accel_note = f"Acceleration: PyTorch device {device_desc}"
+            log(f"[INFO] Bitmap accelerator active on {device_desc}.")
+        else:
+            if device_pref:
+                if device_pref.lower() == "cpu":
+                    log("[INFO] CPU bitmap evaluator selected (Torch acceleration disabled by request).")
+                    accel_note = "Acceleration: CPU bitmap evaluator (requested 'cpu')"
+                else:
+                    log(f"[WARN] Requested Torch device '{device_pref}' is unavailable; using CPU bitmaps.")
+            elif cuda_available():
+                log("[WARN] CUDA runtime detected but PyTorch is unavailable; using CPU bitmaps.")
 
     prog.update(f"Starting nesting… {len(parts)} parts\nMode: {NEST_MODE}, Tries: {SHUFFLE_TRIES}")
 
-    if NEST_MODE.lower()=="bitmap":
-        if SHUFFLE_TRIES>1:
-            placements, sheets = pack_bitmap_multi(parts, W_eff, H_eff, SPACING, PIXELS_PER_UNIT,
-                                                   SHUFFLE_TRIES, SHUFFLE_SEED,
-                                                   progress=prog.update)
+    packing_stats: Dict[str, Any] = {}
+
+    if NEST_MODE.lower() == "bitmap":
+        if SHUFFLE_TRIES > 1:
+            placements, sheets, stats = pack_bitmap_multi(
+                parts,
+                W_eff,
+                H_eff,
+                SPACING,
+                PIXELS_PER_UNIT,
+                SHUFFLE_TRIES,
+                SHUFFLE_SEED,
+                progress=prog.update,
+                mask_ops=mask_ops,
+            )
         else:
-            placements, sheets = pack_bitmap_core(parts, W_eff, H_eff, SPACING, PIXELS_PER_UNIT,
-                                                  progress=prog.update,
-                                                  progress_total=len(parts))[:2]
+            placement_tuple = pack_bitmap_core(
+                parts,
+                W_eff,
+                H_eff,
+                SPACING,
+                PIXELS_PER_UNIT,
+                progress=prog.update,
+                progress_total=len(parts),
+                progress_prefix="Single order\n",
+                mask_ops=mask_ops,
+            )
+            placements, sheets, fill_px = placement_tuple
+            stats = {
+                'fill_pixels': fill_px,
+                'best_seed': 'Area-desc',
+                'tested_orders': ['Area-desc'],
+            }
+        packing_stats = stats or {}
     else:
         placements, sheets = pack_shelves(parts, W_eff, H_eff, SPACING)
+        packing_stats = {
+            'fill_pixels': None,
+            'best_seed': 'Shelf heuristic',
+            'tested_orders': ['Shelf heuristic'],
+        }
 
     if sheets <= 0:
         log("[WARN] Parts exist, but none fit on the sheet.")
         prog.update("Parts exist, but none fit on the sheet.")
+        _write_report(FOLDER, ["Status: aborted (no parts fit on sheet)"])
         prog.close(); return
 
     out = os.path.join(FOLDER, "nested.dxf")
     prog.update(f"Writing output…\n{out}")
     write_r12_dxf(out, sheets, W_eff, H_eff, placements, SHEET_MARGIN)
 
-    # Write report
-    report_path = os.path.join(FOLDER, "nest_report.txt")
-    _report_lines.insert(0, "=== Nesting Report ===")
-    _report_lines.append("")
-    _report_lines.append(f"Saved: {out}")
-    _report_lines.append(f"Mode: {NEST_MODE}")
-    _report_lines.append(f"Sheets: {sheets}")
-    _report_lines.append(f"Margin: {SHEET_MARGIN}")
+    fill_pct_line = None
+    fill_pixels = packing_stats.get('fill_pixels') if isinstance(packing_stats, dict) else None
+    if isinstance(fill_pixels, (int, float)) and fill_pixels is not None:
+        pixel_area = (1.0 / (PIXELS_PER_UNIT or 1)) ** 2
+        utilized_area = fill_pixels * pixel_area
+        total_area = W_eff * H_eff * sheets if sheets else 0.0
+        if total_area > 0:
+            utilization = 100.0 * utilized_area / total_area
+            fill_pct_line = f"Utilized area: {utilized_area:.3f} sq units ({utilization:.1f}% of available)"
 
-    _report_lines.append(f"Spacing: {SPACING}")
-    _report_lines.append(f"Resolution: {PIXELS_PER_UNIT} px/unit")
-    _report_lines.append(f"Shuffle tries: {SHUFFLE_TRIES}{'' if SHUFFLE_SEED is None else f' (seed {SHUFFLE_SEED})'}")
-    _report_lines.append(f"Skipped DXFs: {skipped}")
-    _report_lines.append(f"Rect-align mode: {RECT_ALIGN_MODE}")
-    _report_lines.append(f"Allow mirror: {ALLOW_MIRROR}")
-    _report_lines.append(f"Allow nest in holes: {ALLOW_NEST_IN_HOLES}")
+    tested_orders = packing_stats.get('tested_orders') if isinstance(packing_stats, dict) else None
+    best_seed = packing_stats.get('best_seed') if isinstance(packing_stats, dict) else None
+    if tested_orders:
+        log(f"[INFO] Order heuristics evaluated: {', '.join(tested_orders)}")
+    if best_seed:
+        log(f"[INFO] Best heuristic seed: {best_seed}")
 
-    try:
-        with open(report_path, "w", encoding="utf-8") as rf:
-            rf.write("\n".join(_report_lines))
-    except Exception as e:
-        print(f"[WARN] Could not write report: {e}")
+    extra_lines = [
+        f"Saved: {out}",
+        f"Mode: {NEST_MODE}",
+        f"Sheets: {sheets}",
+        f"Margin: {SHEET_MARGIN}",
+        f"Spacing: {SPACING}",
+        f"Resolution: {PIXELS_PER_UNIT} px/unit",
+        f"Shuffle tries: {SHUFFLE_TRIES}{'' if SHUFFLE_SEED is None else f' (seed {SHUFFLE_SEED})'}",
+        f"Skipped DXFs: {skipped}",
+        f"Rect-align mode: {RECT_ALIGN_MODE}",
+        f"Allow mirror: {ALLOW_MIRROR}",
+        f"Allow nest in holes: {ALLOW_NEST_IN_HOLES}",
+        accel_note,
+    ]
+    if using_cuda:
+        extra_lines.append("GPU acceleration engaged: NVIDIA CUDA device utilized for bitmap placement.")
+    if best_seed:
+        extra_lines.append(f"Best heuristic seed: {best_seed}")
+    if tested_orders:
+        extra_lines.append(f"Order heuristics evaluated: {', '.join(tested_orders)}")
+    if fill_pct_line:
+        extra_lines.append(fill_pct_line)
+    extra_lines.append("Status: complete")
+
+    report_path = _write_report(FOLDER, extra_lines)
 
     prog.update("Done! Opening folder and report…")
     prog.close()
 
-    try: os.startfile(FOLDER)
-    except: pass
-    try: os.startfile(report_path)
-    except: pass
+    if report_path:
+        try: os.startfile(FOLDER)
+        except Exception:
+            pass
+        try: os.startfile(report_path)
+        except Exception:
+            pass
 
 if __name__ == "__main__":
     import argparse
@@ -1319,6 +1549,11 @@ if __name__ == "__main__":
         help="Number of worker processes used for bitmap evaluation (bitmap mode).",
     )
     parser.add_argument(
+        "--device",
+        default=BITMAP_DEVICE,
+        help="Optional PyTorch device string for bitmap acceleration (e.g., 'cuda', 'cuda:0', 'cpu').",
+    )
+    parser.add_argument(
         "--allow-mirror",
         dest="allow_mirror",
         action="store_true",
@@ -1362,8 +1597,27 @@ if __name__ == "__main__":
     SHUFFLE_TRIES = max(1, int(args.tries))
     SHUFFLE_SEED = args.seed
     BITMAP_EVAL_WORKERS = args.workers
+    BITMAP_DEVICE = args.device
     ALLOW_MIRROR = args.allow_mirror
     ALLOW_NEST_IN_HOLES = args.allow_holes
     RECT_ALIGN_MODE = args.rect_align
 
-    main()
+    exit_code = 0
+    try:
+        main()
+    except Exception as exc:  # pragma: no cover - defensive CLI wrapper
+        exit_code = 1
+        tb = traceback.format_exc()
+        log(f"[ERROR] Unhandled exception: {exc}")
+        sys.stderr.write(tb)
+        extra = ["Status: failed (unexpected error)", "Traceback:"] + tb.rstrip().splitlines()
+        _write_report(FOLDER, extra)
+    finally:
+        pause_ok = IS_WINDOWS and not sys.argv[1:] and sys.stdin is not None and sys.stdin.isatty()
+        if pause_ok:
+            try:
+                input("Press Enter to exit…")
+            except Exception:
+                pass
+
+    sys.exit(exit_code)


### PR DESCRIPTION
## Summary
- add a console-based progress reporter for non-Windows hosts and log heuristic usage in the report
- seed the bitmap shuffler with a Deepnest-inspired ordering heuristic and propagate packing statistics to the report
- document the new console behaviour and heuristic improvements in the README

## Testing
- python3 nest_dxf_qty_optimized_shuffle.py --folder 'For waterjet cutting' --pixels-per-unit 6 --tries 2 --device cpu

------
https://chatgpt.com/codex/tasks/task_e_68d5eab18ab48320ab5e6494fc001afb