### PR TITLE
Remove duplicated bitmap worker configuration

### DIFF
--- a/nest_dxf_qty_optimized_shuffle.py
+++ b/nest_dxf_qty_optimized_shuffle.py
@@ -55,31 +55,6 @@ BITMAP_EVAL_WORKERS = None
 # Optional PyTorch device string for the bitmap accelerator ("cuda", "cuda:0", "cpu", etc.).
 BITMAP_DEVICE = None  # type: Optional[str]
 
-# Worker processes used by the bitmap evaluator.  Leaving this at ``None``
-# lets the script auto-detect the CPU count once ``os`` is available.
-BITMAP_EVAL_WORKERS = None
-
-# Optional PyTorch device string for the bitmap accelerator ("cuda", "cuda:0", "cpu", etc.).
-BITMAP_DEVICE = None  # type: Optional[str]
-
-# Worker processes used by the bitmap evaluator.  Leaving this at ``None``
-# lets the script auto-detect the CPU count once ``os`` is available.
-BITMAP_EVAL_WORKERS = None
-
-# Optional PyTorch device string for the bitmap accelerator ("cuda", "cuda:0", "cpu", etc.).
-BITMAP_DEVICE = None  # type: Optional[str]
-
-# Worker processes used by the bitmap evaluator.  Leaving this at ``None``
-# lets the script auto-detect the CPU count once ``os`` is available.
-BITMAP_EVAL_WORKERS = None
-
-# Optional PyTorch device string for the bitmap accelerator ("cuda", "cuda:0", "cpu", etc.).
-BITMAP_DEVICE = None  # type: Optional[str]
-
-# Worker processes used by the bitmap evaluator.  Leaving this at ``None``
-# lets the script auto-detect the CPU count once ``os`` is available.
-BITMAP_EVAL_WORKERS = None
-
 
 
 # Multi-try randomization (bitmap only)


### PR DESCRIPTION
## Summary
- remove repeated BITMAP_EVAL_WORKERS and BITMAP_DEVICE assignments from the configuration header to avoid accidental overrides

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d62d79e18c8320b1e3969f77e1359d